### PR TITLE
[enh] add custom template following sarah gibson rec

### DIFF
--- a/binderhub/config.yaml
+++ b/binderhub/config.yaml
@@ -86,6 +86,29 @@ config:
     use_registry: true
     image_prefix: conpdev/binder.conp.cloud-
 
+initContainers:
+  - name: git-clone-templates
+    image: alpine/git
+    args:
+      - clone
+      - --single-branch
+      - --branch=master
+      - --depth=1
+      - --
+      - https://github.com/neurolibre/binderhub-template.git
+      - /etc/binderhub/custom
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+      - name: custom-templates
+        mountPath: /etc/binderhub/custom
+extraVolumes:
+  - name: custom-templates
+    emptyDir: {}
+extraVolumeMounts:
+  - name: custom-templates
+    mountPath: /etc/binderhub/custom
+
 service:
   type: NodePort
 


### PR DESCRIPTION
Addresses #8.

Following recommendations from Sarah Gibson on [Jupyter Discourse](https://discourse.jupyter.org/t/custom-html-template-not-showing/1238/5), updates the BinderHub config.yaml to include `initContainers` as a top-level key.